### PR TITLE
Fix first release errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 readme = "Readme.md"
 license = "MIT"
+description = "A miltr protocol implementation in pure rust"
 
 [workspace]
 members = ["server", "client", "common", "utils"]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -2,8 +2,9 @@
 name = "miltr-client"
 version = "0.1.0"
 edition = "2021"
-readme = "Readme.md"
+readme = "../Readme.md"
 license = "MIT"
+description = "A miltr client library in pure rust"
 
 # MSRV is considered exempt from SemVer upgrades
 # Current limitation is: "RPITIT Language Feature"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -2,8 +2,9 @@
 name = "miltr-common"
 version = "0.1.0"
 edition = "2021"
-readme = "Readme.md"
+readme = "../Readme.md"
 license = "MIT"
+description = "A miltr commons library in pure rust"
 
 # MSRV is considered exempt from SemVer upgrades
 # Current limitation is: "RPITIT Language Feature"

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -ex 
+
+cargo login
+
+cd utils
+cargo publish
+sleep 20
+
+cd common
+cargo publish
+sleep 20
+
+cd server
+cargo publish
+sleep 20
+
+cd client
+cargo publish
+sleep 20

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -2,8 +2,9 @@
 name = "miltr-server"
 version = "0.1.0"
 edition = "2021"
-readme = "Readme.md"
+readme = "../Readme.md"
 license = "MIT"
+description = "A miltr server library in pure rust"
 
 # MSRV is considered exempt from SemVer upgrades
 # Current limitation is: "async-dropper-simple"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -2,6 +2,8 @@
 name = "miltr-utils"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
+description = "A miltr utils library in pure rust"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Just release a first version to crates.io and fix problems along the way.